### PR TITLE
Removed distracting/misleading where clause

### DIFF
--- a/02_Functions_Types_Dispatch.ipynb
+++ b/02_Functions_Types_Dispatch.ipynb
@@ -651,7 +651,7 @@
    "outputs": [],
    "source": [
     "equal_type_and_integer(x::T, y::T) where {T <: Integer} = true\n",
-    "equal_type_and_integer(x, y) where {T <: Integer} = false"
+    "equal_type_and_integer(x, y) = false"
    ]
   },
   {


### PR DESCRIPTION
Hey, I just stumbled over it and found it distracting, checking where that T is even used. I guess it was jsut some copy & paste mistake rather than intended for comparison (?) 😄 